### PR TITLE
Align fallback embeddings with HF model

### DIFF
--- a/backend/core/rag_engine.py
+++ b/backend/core/rag_engine.py
@@ -16,7 +16,8 @@ except ModuleNotFoundError:  # pragma: no cover - caminho utilizado na execucao 
 class _DeterministicFallbackEmbeddings:
     """Simple deterministic embeddings used when HuggingFace models are unavailable."""
 
-    def __init__(self, embedding_size: int = 384) -> None:
+    def __init__(self, embedding_size: int = 768) -> None:
+        # Keep this dimension aligned with the primary HuggingFace embedding model.
         self.embedding_size = embedding_size
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:


### PR DESCRIPTION
## Summary
- align the deterministic fallback embedding size with the 768 dimensions produced by the HuggingFace model
- document that the offline fallback must stay in sync with the primary embedding configuration

## Testing
- pytest -q
- python - <<'PY' (manual fallback upload/query smoke)
- RAG_ENABLE_HF_EMBEDDINGS=1 python - <<'PY' (manual HuggingFace upload/query smoke)
- RAG_ENABLE_HF_EMBEDDINGS=1 pytest -q *(fails: FastAPI test server times out while HuggingFace embeddings initialize ~15s)*

------
https://chatgpt.com/codex/tasks/task_e_68d026cfe9f88320ac2d02ccc19c4a64