### PR TITLE
Align fallback embedding dimension with HuggingFace model

### DIFF
--- a/backend/core/rag_engine.py
+++ b/backend/core/rag_engine.py
@@ -17,7 +17,7 @@ class _DeterministicFallbackEmbeddings:
     """Simple deterministic embeddings used when HuggingFace models are unavailable."""
 
     def __init__(self, embedding_size: int = 768) -> None:
-        # Keep this dimension aligned with the primary HuggingFace embedding model.
+        # Keep this fallback dimension in sync with the HuggingFace embedding model (currently 768).
         self.embedding_size = embedding_size
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:


### PR DESCRIPTION
## Summary
- align the deterministic fallback embedding dimension with the HuggingFace encoder size and document the coupling

## Testing
- RAG_ENABLE_HF_EMBEDDINGS=0 python test_rag.py
- RAG_ENABLE_HF_EMBEDDINGS=1 python test_rag.py

------
https://chatgpt.com/codex/tasks/task_e_68d038b17d9883209c53964930974baf