### PR TITLE
Remove unused frontend service from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,3 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
-
-  frontend:
-    build: ./frontend
-    ports:
-      - "3000:3000"
-    volumes:
-      - ./frontend:/app
-    depends_on:
-      - backend


### PR DESCRIPTION
## Summary
- remove the unused frontend service from docker-compose.yml to match the current project layout

## Testing
- docker-compose up *(fails: docker-compose not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04258f4708320b5fe0bd67af8e2b6