### PR TITLE
Ensure FastAPI JSON responses advertise UTF-8

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import List, Dict, Any
 import uvicorn
@@ -11,7 +12,19 @@ except ModuleNotFoundError:  # pragma: no cover - compatibilidade para execucao 
     from core.rag_engine import RAGEngine  # type: ignore
     from core.document_processor import DocumentProcessor  # type: ignore
 
-app = FastAPI(title="IA Corporativa PMEs", version="0.1.0")
+
+
+class UTF8JSONResponse(JSONResponse):
+    """Default JSON response configured to advertise UTF-8 encoding."""
+
+    media_type = "application/json; charset=utf-8"
+
+
+app = FastAPI(
+    title="IA Corporativa PMEs",
+    version="0.1.0",
+    default_response_class=UTF8JSONResponse,
+)
 
 # CORS para desenvolvimento
 app.add_middleware(

--- a/tests/test_utf8_content_type.py
+++ b/tests/test_utf8_content_type.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import io
+import time
+
+import requests
+
+
+API_ROOT = "http://127.0.0.1:8000/api/v1"
+ACCENTED_FILENAME = "integration-utf8.txt"
+ACCENTED_TEXT = "Informação estratégica: João lidera a operação diária."
+
+
+def _wait_for_accented_fragment(
+    question: str,
+    expected_fragment: str,
+    attempts: int = 10,
+    delay: float = 0.2,
+):
+    last_response: requests.Response | None = None
+    for _ in range(attempts):
+        response = requests.post(
+            f"{API_ROOT}/query",
+            json={"question": question, "top_k": 5},
+            timeout=10,
+        )
+        response.raise_for_status()
+        last_response = response
+        if expected_fragment in response.text:
+            return response
+        time.sleep(delay)
+
+    detail = None if last_response is None else last_response.text
+    raise AssertionError(
+        f"Accented fragment '{expected_fragment}' not found in query response: {detail}"
+    )
+
+
+def test_json_responses_advertise_utf8_and_preserve_accents():
+    health_response = requests.get(f"{API_ROOT}/health", timeout=10)
+    health_response.raise_for_status()
+    assert (
+        health_response.headers.get("content-type")
+        == "application/json; charset=utf-8"
+    )
+
+    files = {
+        "file": (
+            ACCENTED_FILENAME,
+            io.BytesIO(ACCENTED_TEXT.encode("utf-8")),
+            "text/plain",
+        )
+    }
+    upload_response = requests.post(
+        f"{API_ROOT}/documents", files=files, timeout=10
+    )
+    upload_response.raise_for_status()
+
+    query_response = _wait_for_accented_fragment(
+        ACCENTED_TEXT, "Informação"
+    )
+    assert (
+        query_response.headers.get("content-type")
+        == "application/json; charset=utf-8"
+    )
+
+    data = query_response.json()
+    sources_text = " ".join(
+        source.get("text", "") for source in data.get("sources", [])
+    )
+    assert "Informação" in sources_text
+    assert "João" in sources_text


### PR DESCRIPTION
## Summary
- configure FastAPI to use a JSON response class that explicitly sets the UTF-8 media type
- add an integration test that verifies the content-type header and UTF-8 decoding of accented text

## Testing
- pytest tests/test_rag_engine.py
- pytest tests/test_utf8_content_type.py

------
https://chatgpt.com/codex/tasks/task_e_68d04a2492f48320adfb07ecab12566e