### PR TITLE
Normalize upload filename extension handling and add uppercase tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -53,13 +55,16 @@ async def query_documents(request: QueryRequest):
 async def upload_document(file: UploadFile = File(...)):
     """Upload e indexação de novo documento"""
     try:
+        filename = file.filename or ""
+        extension = Path(filename).suffix.lower()
+
         # Validar tipo de arquivo
-        if not file.filename.endswith((".pdf", ".txt")):
+        if extension not in {".pdf", ".txt"}:
             raise HTTPException(400, "Apenas PDF e TXT são suportados")
 
         # Processar e indexar
         content = await file.read()
-        chunks = doc_processor.process_document(content, file.filename)
+        chunks = doc_processor.process_document(content, filename)
         rag_engine.index_documents(chunks)
 
         return {"status": "success", "chunks_indexed": len(chunks)}

--- a/tests/test_upload_uppercase_extensions.py
+++ b/tests/test_upload_uppercase_extensions.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import io
+
+import httpx
+import pytest
+
+from backend import main
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.parametrize(
+    ("filename", "content", "content_type"),
+    [
+        ("DOCUMENT.PDF", b"%PDF-1.4 fake pdf content", "application/pdf"),
+        ("NOTES.TXT", b"Plain text content", "text/plain"),
+    ],
+)
+async def test_upload_accepts_uppercase_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    content: bytes,
+    content_type: str,
+) -> None:
+    processed_calls: list[tuple[bytes, str]] = []
+    indexed_calls: list[list[dict[str, str]]] = []
+
+    def fake_process_document(file_bytes: bytes, received_filename: str):
+        processed_calls.append((file_bytes, received_filename))
+        return [{"text": "chunk", "source": received_filename, "doc_id": "dummy"}]
+
+    def fake_index_documents(chunks: list[dict[str, str]]):
+        indexed_calls.append(chunks)
+
+    monkeypatch.setattr(main.doc_processor, "process_document", fake_process_document)
+    monkeypatch.setattr(main.rag_engine, "index_documents", fake_index_documents)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=main.app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/api/v1/documents",
+            files={"file": (filename, io.BytesIO(content), content_type)},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "success"
+
+    assert processed_calls[-1][1] == filename
+    assert indexed_calls[-1] == [{"text": "chunk", "source": filename, "doc_id": "dummy"}]


### PR DESCRIPTION
## Summary
- normalize uploaded filenames before validating allowed extensions so uppercase suffixes are accepted
- pass the normalized filename to the document processor
- add an async API test that uploads .PDF and .TXT files with uppercase extensions

## Testing
- pytest tests/test_upload_uppercase_extensions.py

------
https://chatgpt.com/codex/tasks/task_e_68d04a2a09d88320b8a88e92b87e78ff