### PR TITLE
Normalize PDF filename extension handling

### DIFF
--- a/backend/core/document_processor.py
+++ b/backend/core/document_processor.py
@@ -19,7 +19,9 @@ class DocumentProcessor:
 
         doc_id = hashlib.sha256(content).hexdigest()
         
-        if filename.endswith('.pdf'):
+        normalized_filename = filename.lower()
+
+        if normalized_filename.endswith('.pdf'):
             # Extrair texto do PDF
             pdf_document = fitz.open(stream=content, filetype="pdf")
             for page in pdf_document:

--- a/tests/test_upload_uppercase_extensions.py
+++ b/tests/test_upload_uppercase_extensions.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import hashlib
 import io
 
+import fitz
 import httpx
 import pytest
 
 from backend import main
+from backend.core.document_processor import DocumentProcessor
 
 
 pytestmark = pytest.mark.anyio
@@ -57,3 +60,36 @@ async def test_upload_accepts_uppercase_extensions(
 
     assert processed_calls[-1][1] == filename
     assert indexed_calls[-1] == [{"text": "chunk", "source": filename, "doc_id": "dummy"}]
+
+
+async def test_document_processor_extracts_uppercase_pdf_with_pymupdf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text_content = "Uppercase PDF Content"
+
+    pdf_document = fitz.open()
+    try:
+        page = pdf_document.new_page()
+        page.insert_text((72, 72), text_content)
+        pdf_bytes = pdf_document.tobytes()
+    finally:
+        pdf_document.close()
+
+    processor = DocumentProcessor()
+    expected_doc_id = hashlib.sha256(pdf_bytes).hexdigest()
+    opened_with_pymupdf = False
+    real_open = fitz.open
+
+    def tracking_open(*args, **kwargs):
+        nonlocal opened_with_pymupdf
+        opened_with_pymupdf = True
+        return real_open(*args, **kwargs)
+
+    monkeypatch.setattr("backend.core.document_processor.fitz.open", tracking_open)
+
+    chunks = processor.process_document(pdf_bytes, "SAMPLE.PDF")
+
+    assert opened_with_pymupdf is True
+    assert any(text_content in chunk["text"] for chunk in chunks)
+    assert all(chunk["source"] == "SAMPLE.PDF" for chunk in chunks)
+    assert all(chunk["doc_id"] == expected_doc_id for chunk in chunks)


### PR DESCRIPTION
## Summary
- normalize the uploaded filename before checking for the PDF extension so uppercase names use the PDF parser
- extend the uppercase extension test module with a case that verifies DocumentProcessor uses PyMuPDF for uppercase PDFs

## Testing
- pytest tests/test_upload_uppercase_extensions.py

------
https://chatgpt.com/codex/tasks/task_e_68d04c8e41a883209f471d9541b97037