### PR TITLE
Honor zero overrides for LLM generator sampling

### DIFF
--- a/backend/core/llm_generator.py
+++ b/backend/core/llm_generator.py
@@ -33,10 +33,24 @@ class LLMGenerator:
     ) -> None:
         self.model_name = model_name or os.getenv("RAG_LLM_MODEL", "google/flan-t5-base")
         self.task = task or os.getenv("RAG_LLM_TASK", "text2text-generation")
-        self.max_new_tokens = max_new_tokens or int(os.getenv("RAG_LLM_MAX_NEW_TOKENS", "256"))
-        self.temperature = temperature or float(os.getenv("RAG_LLM_TEMPERATURE", "0.1"))
-        self.top_p = top_p or float(os.getenv("RAG_LLM_TOP_P", "0.9"))
-        self.max_context_chars = max_context_chars or int(os.getenv("RAG_LLM_MAX_CONTEXT_CHARS", "6000"))
+        self.max_new_tokens = (
+            max_new_tokens
+            if max_new_tokens is not None
+            else int(os.getenv("RAG_LLM_MAX_NEW_TOKENS", "256"))
+        )
+        self.temperature = (
+            temperature
+            if temperature is not None
+            else float(os.getenv("RAG_LLM_TEMPERATURE", "0.1"))
+        )
+        self.top_p = (
+            top_p if top_p is not None else float(os.getenv("RAG_LLM_TOP_P", "0.9"))
+        )
+        self.max_context_chars = (
+            max_context_chars
+            if max_context_chars is not None
+            else int(os.getenv("RAG_LLM_MAX_CONTEXT_CHARS", "6000"))
+        )
         self.prompt_template = prompt_template or DEFAULT_PROMPT
         self._pipeline: Optional[Pipeline] = None
         self._load_error: Optional[str] = None

--- a/tests/test_llm_generator.py
+++ b/tests/test_llm_generator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from backend.core.llm_generator import LLMGenerator
+from langchain.docstore.document import Document
+
+
+def test_generate_uses_zero_temperature(monkeypatch) -> None:
+    monkeypatch.setenv("RAG_ENABLE_LLM", "0")
+
+    generator = LLMGenerator(temperature=0.0)
+    mock_pipeline = MagicMock(return_value=[{"generated_text": "resultado"}])
+    generator._pipeline = mock_pipeline
+
+    documents = [Document(page_content="conteudo", metadata={"source": "fonte"})]
+
+    result = generator.generate("pergunta?", documents)
+
+    assert result == "resultado"
+
+    assert mock_pipeline.call_count == 1
+    _, kwargs = mock_pipeline.call_args
+    assert kwargs["temperature"] == 0.0
+    assert kwargs["do_sample"] is False


### PR DESCRIPTION
## Summary
- ensure the LLM generator keeps zero-valued overrides for decoding parameters instead of falling back to environment defaults
- add a unit test that verifies generation with temperature=0.0 disables sampling

## Testing
- pytest tests/test_llm_generator.py
- pytest tests/test_rag_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d0504861648320857b57ae56803f8a